### PR TITLE
usar length(string) para pegar as strings vazias localmente e instalado no banco ao invés de '''' (4 single quotes)

### DIFF
--- a/edgv_213/aquisicao_2CGEO/aux_moldura_a.qml
+++ b/edgv_213/aquisicao_2CGEO/aux_moldura_a.qml
@@ -1,0 +1,463 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="2.18.16" simplifyAlgorithm="0" minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" readOnly="0" simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
+  <edittypes>
+    <edittype widgetv2type="TextEdit" name="id">
+      <widgetv2config IsMultiline="0" fieldEditable="0" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="mi">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="inom">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="escala">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="nomecarta">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="anoaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="engrespaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="opaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainicioaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="engresprevisaoaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="oprevisaoaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainiciorevaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimrevaquisicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="engrespreambulacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="opreambulacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainicioreambulacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimreambulacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="oprevisaoreambulacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="engrespvalidacaoedicao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="opvalidacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainiciovalidacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimvalidacao">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="opedicao1">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainicioedicao1">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimedicao1">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="oprevedicao1">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainiciorevedicao1">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimrevedicao1">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="opedicao2">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datainicioedicao2">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="datafimedicao2">
+      <widgetv2config IsMultiline="0" fieldEditable="1" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+    <edittype widgetv2type="TextEdit" name="area_otf">
+      <widgetv2config IsMultiline="0" fieldEditable="0" constraint="" UseHtml="0" labelOnTop="0" constraintDescription="" notNull="0"/>
+    </edittype>
+  </edittypes>
+  <renderer-v2 forceraster="0" symbollevels="0" type="singleSymbol" enableorderby="0">
+    <symbols>
+      <symbol alpha="1" clip_to_extent="1" type="fill" name="0">
+        <layer pass="0" class="SimpleFill" locked="0">
+          <prop k="border_width_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="color" v="190,117,92,0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="255,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="2.06"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale scalemethod="diameter"/>
+  </renderer-v2>
+  <labeling type="simple"/>
+  <customproperties>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="labeling" value="pal"/>
+    <property key="labeling/addDirectionSymbol" value="false"/>
+    <property key="labeling/angleOffset" value="0"/>
+    <property key="labeling/blendMode" value="0"/>
+    <property key="labeling/bufferBlendMode" value="0"/>
+    <property key="labeling/bufferColorA" value="255"/>
+    <property key="labeling/bufferColorB" value="255"/>
+    <property key="labeling/bufferColorG" value="255"/>
+    <property key="labeling/bufferColorR" value="255"/>
+    <property key="labeling/bufferDraw" value="false"/>
+    <property key="labeling/bufferJoinStyle" value="128"/>
+    <property key="labeling/bufferNoFill" value="false"/>
+    <property key="labeling/bufferSize" value="1"/>
+    <property key="labeling/bufferSizeInMapUnits" value="false"/>
+    <property key="labeling/bufferSizeMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/bufferTransp" value="0"/>
+    <property key="labeling/centroidInside" value="false"/>
+    <property key="labeling/centroidWhole" value="false"/>
+    <property key="labeling/decimals" value="3"/>
+    <property key="labeling/displayAll" value="false"/>
+    <property key="labeling/dist" value="0"/>
+    <property key="labeling/distInMapUnits" value="false"/>
+    <property key="labeling/distMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/drawLabels" value="false"/>
+    <property key="labeling/enabled" value="false"/>
+    <property key="labeling/fieldName" value=""/>
+    <property key="labeling/fitInPolygonOnly" value="false"/>
+    <property key="labeling/fontCapitals" value="0"/>
+    <property key="labeling/fontFamily" value="Noto Sans"/>
+    <property key="labeling/fontItalic" value="true"/>
+    <property key="labeling/fontLetterSpacing" value="0"/>
+    <property key="labeling/fontLimitPixelSize" value="false"/>
+    <property key="labeling/fontMaxPixelSize" value="10000"/>
+    <property key="labeling/fontMinPixelSize" value="3"/>
+    <property key="labeling/fontSize" value="10"/>
+    <property key="labeling/fontSizeInMapUnits" value="false"/>
+    <property key="labeling/fontSizeMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/fontStrikeout" value="false"/>
+    <property key="labeling/fontUnderline" value="false"/>
+    <property key="labeling/fontWeight" value="75"/>
+    <property key="labeling/fontWordSpacing" value="0"/>
+    <property key="labeling/formatNumbers" value="false"/>
+    <property key="labeling/isExpression" value="true"/>
+    <property key="labeling/labelOffsetInMapUnits" value="true"/>
+    <property key="labeling/labelOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/labelPerPart" value="false"/>
+    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+    <property key="labeling/limitNumLabels" value="false"/>
+    <property key="labeling/maxCurvedCharAngleIn" value="25"/>
+    <property key="labeling/maxCurvedCharAngleOut" value="-25"/>
+    <property key="labeling/maxNumLabels" value="2000"/>
+    <property key="labeling/mergeLines" value="false"/>
+    <property key="labeling/minFeatureSize" value="0"/>
+    <property key="labeling/multilineAlign" value="4294967295"/>
+    <property key="labeling/multilineHeight" value="1"/>
+    <property key="labeling/namedStyle" value="Bold Italic"/>
+    <property key="labeling/obstacle" value="true"/>
+    <property key="labeling/obstacleFactor" value="1"/>
+    <property key="labeling/obstacleType" value="0"/>
+    <property key="labeling/offsetType" value="0"/>
+    <property key="labeling/placeDirectionSymbol" value="0"/>
+    <property key="labeling/placement" value="1"/>
+    <property key="labeling/placementFlags" value="10"/>
+    <property key="labeling/plussign" value="false"/>
+    <property key="labeling/predefinedPositionOrder" value="TR,TL,BR,BL,R,L,TSR,BSR"/>
+    <property key="labeling/preserveRotation" value="true"/>
+    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+    <property key="labeling/priority" value="5"/>
+    <property key="labeling/quadOffset" value="4"/>
+    <property key="labeling/repeatDistance" value="0"/>
+    <property key="labeling/repeatDistanceMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/repeatDistanceUnit" value="1"/>
+    <property key="labeling/reverseDirectionSymbol" value="false"/>
+    <property key="labeling/rightDirectionSymbol" value=">"/>
+    <property key="labeling/scaleMax" value="10000000"/>
+    <property key="labeling/scaleMin" value="1"/>
+    <property key="labeling/scaleVisibility" value="false"/>
+    <property key="labeling/shadowBlendMode" value="6"/>
+    <property key="labeling/shadowColorB" value="0"/>
+    <property key="labeling/shadowColorG" value="0"/>
+    <property key="labeling/shadowColorR" value="0"/>
+    <property key="labeling/shadowDraw" value="false"/>
+    <property key="labeling/shadowOffsetAngle" value="135"/>
+    <property key="labeling/shadowOffsetDist" value="1"/>
+    <property key="labeling/shadowOffsetGlobal" value="true"/>
+    <property key="labeling/shadowOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/shadowOffsetUnits" value="1"/>
+    <property key="labeling/shadowRadius" value="1.5"/>
+    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+    <property key="labeling/shadowRadiusMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/shadowRadiusUnits" value="1"/>
+    <property key="labeling/shadowScale" value="100"/>
+    <property key="labeling/shadowTransparency" value="30"/>
+    <property key="labeling/shadowUnder" value="0"/>
+    <property key="labeling/shapeBlendMode" value="0"/>
+    <property key="labeling/shapeBorderColorA" value="255"/>
+    <property key="labeling/shapeBorderColorB" value="128"/>
+    <property key="labeling/shapeBorderColorG" value="128"/>
+    <property key="labeling/shapeBorderColorR" value="128"/>
+    <property key="labeling/shapeBorderWidth" value="0"/>
+    <property key="labeling/shapeBorderWidthMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/shapeBorderWidthUnits" value="1"/>
+    <property key="labeling/shapeDraw" value="false"/>
+    <property key="labeling/shapeFillColorA" value="255"/>
+    <property key="labeling/shapeFillColorB" value="255"/>
+    <property key="labeling/shapeFillColorG" value="255"/>
+    <property key="labeling/shapeFillColorR" value="255"/>
+    <property key="labeling/shapeJoinStyle" value="64"/>
+    <property key="labeling/shapeOffsetMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/shapeOffsetUnits" value="1"/>
+    <property key="labeling/shapeOffsetX" value="0"/>
+    <property key="labeling/shapeOffsetY" value="0"/>
+    <property key="labeling/shapeRadiiMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/shapeRadiiUnits" value="1"/>
+    <property key="labeling/shapeRadiiX" value="0"/>
+    <property key="labeling/shapeRadiiY" value="0"/>
+    <property key="labeling/shapeRotation" value="0"/>
+    <property key="labeling/shapeRotationType" value="0"/>
+    <property key="labeling/shapeSVGFile" value=""/>
+    <property key="labeling/shapeSizeMapUnitScale" value="0,0,0,0,0,0"/>
+    <property key="labeling/shapeSizeType" value="0"/>
+    <property key="labeling/shapeSizeUnits" value="1"/>
+    <property key="labeling/shapeSizeX" value="0"/>
+    <property key="labeling/shapeSizeY" value="0"/>
+    <property key="labeling/shapeTransparency" value="0"/>
+    <property key="labeling/shapeType" value="0"/>
+    <property key="labeling/substitutions" value="&lt;substitutions/>"/>
+    <property key="labeling/textColorA" value="255"/>
+    <property key="labeling/textColorB" value="0"/>
+    <property key="labeling/textColorG" value="0"/>
+    <property key="labeling/textColorR" value="0"/>
+    <property key="labeling/textTransp" value="0"/>
+    <property key="labeling/upsidedownLabels" value="0"/>
+    <property key="labeling/useSubstitutions" value="false"/>
+    <property key="labeling/wrapChar" value=""/>
+    <property key="labeling/xOffset" value="0"/>
+    <property key="labeling/yOffset" value="0"/>
+    <property key="labeling/zIndex" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerTransparency>0</layerTransparency>
+  <displayfield>id</displayfield>
+  <label>0</label>
+  <labelattributes>
+    <label fieldname="" text="Rótulo"/>
+    <family fieldname="" name="Noto Sans"/>
+    <size fieldname="" units="pt" value="12"/>
+    <bold fieldname="" on="0"/>
+    <italic fieldname="" on="0"/>
+    <underline fieldname="" on="0"/>
+    <strikeout fieldname="" on="0"/>
+    <color fieldname="" red="0" blue="0" green="0"/>
+    <x fieldname=""/>
+    <y fieldname=""/>
+    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+    <angle fieldname="" value="0" auto="0"/>
+    <alignment fieldname="" value="center"/>
+    <buffercolor fieldname="" red="255" blue="255" green="255"/>
+    <buffersize fieldname="" units="pt" value="1"/>
+    <bufferenabled fieldname="" on=""/>
+    <multilineenabled fieldname="" on=""/>
+    <selectedonly on=""/>
+  </labelattributes>
+  <SingleCategoryDiagramRenderer diagramType="Histogram" sizeLegend="0" attributeLegend="1">
+    <DiagramCategory penColor="#000000" labelPlacementMethod="XHeight" penWidth="0" diagramOrientation="Up" sizeScale="0,0,0,0,0,0" minimumSize="0" barWidth="5" penAlpha="255" maxScaleDenominator="1e+08" backgroundColor="#ffffff" transparency="0" width="15" scaleDependency="Area" backgroundAlpha="255" angleOffset="1440" scaleBasedVisibility="0" enabled="0" height="15" lineSizeScale="0,0,0,0,0,0" sizeType="MM" lineSizeType="MM" minScaleDenominator="inf">
+      <fontProperties description="Noto Sans,10,-1,0,50,0,0,0,0,0" style=""/>
+      <attribute field="" color="#000000" label=""/>
+    </DiagramCategory>
+    <symbol alpha="1" clip_to_extent="1" type="marker" name="sizeSymbol">
+      <layer pass="0" class="SimpleMarker" locked="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,0,0,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0"/>
+        <prop k="outline_width_map_unit_scale" v="0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="2"/>
+        <prop k="size_map_unit_scale" v="0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+      </layer>
+    </symbol>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings yPosColumn="-1" showColumn="-1" linePlacementFlags="10" placement="0" dist="0" xPosColumn="-1" priority="0" obstacle="0" zIndex="0" showAll="1"/>
+  <annotationform>.</annotationform>
+  <aliases>
+    <alias field="id" index="0" name=""/>
+    <alias field="mi" index="1" name=""/>
+    <alias field="inom" index="2" name=""/>
+    <alias field="escala" index="3" name=""/>
+    <alias field="nomecarta" index="4" name=""/>
+    <alias field="anoaquisicao" index="5" name=""/>
+    <alias field="engrespaquisicao" index="6" name=""/>
+    <alias field="opaquisicao" index="7" name=""/>
+    <alias field="datainicioaquisicao" index="8" name=""/>
+    <alias field="datafimaquisicao" index="9" name=""/>
+    <alias field="engresprevisaoaquisicao" index="10" name=""/>
+    <alias field="oprevisaoaquisicao" index="11" name=""/>
+    <alias field="datainiciorevaquisicao" index="12" name=""/>
+    <alias field="datafimrevaquisicao" index="13" name=""/>
+    <alias field="engrespreambulacao" index="14" name=""/>
+    <alias field="opreambulacao" index="15" name=""/>
+    <alias field="datainicioreambulacao" index="16" name=""/>
+    <alias field="datafimreambulacao" index="17" name=""/>
+    <alias field="oprevisaoreambulacao" index="18" name=""/>
+    <alias field="engrespvalidacaoedicao" index="19" name=""/>
+    <alias field="opvalidacao" index="20" name=""/>
+    <alias field="datainiciovalidacao" index="21" name=""/>
+    <alias field="datafimvalidacao" index="22" name=""/>
+    <alias field="opedicao1" index="23" name=""/>
+    <alias field="datainicioedicao1" index="24" name=""/>
+    <alias field="datafimedicao1" index="25" name=""/>
+    <alias field="oprevedicao1" index="26" name=""/>
+    <alias field="datainiciorevedicao1" index="27" name=""/>
+    <alias field="datafimrevedicao1" index="28" name=""/>
+    <alias field="opedicao2" index="29" name=""/>
+    <alias field="datainicioedicao2" index="30" name=""/>
+    <alias field="datafimedicao2" index="31" name=""/>
+    <alias field="area_otf" index="32" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <attributeactions default="-1"/>
+  <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+    <columns>
+      <column width="-1" hidden="0" type="field" name="id"/>
+      <column width="-1" hidden="0" type="field" name="mi"/>
+      <column width="-1" hidden="0" type="field" name="inom"/>
+      <column width="-1" hidden="0" type="field" name="escala"/>
+      <column width="-1" hidden="0" type="field" name="nomecarta"/>
+      <column width="-1" hidden="0" type="field" name="anoaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="engrespaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="opaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="datainicioaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="datafimaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="engresprevisaoaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="oprevisaoaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="datainiciorevaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="datafimrevaquisicao"/>
+      <column width="-1" hidden="0" type="field" name="engrespreambulacao"/>
+      <column width="-1" hidden="0" type="field" name="opreambulacao"/>
+      <column width="-1" hidden="0" type="field" name="datainicioreambulacao"/>
+      <column width="-1" hidden="0" type="field" name="datafimreambulacao"/>
+      <column width="-1" hidden="0" type="field" name="oprevisaoreambulacao"/>
+      <column width="-1" hidden="0" type="field" name="engrespvalidacaoedicao"/>
+      <column width="-1" hidden="0" type="field" name="opvalidacao"/>
+      <column width="-1" hidden="0" type="field" name="datainiciovalidacao"/>
+      <column width="-1" hidden="0" type="field" name="datafimvalidacao"/>
+      <column width="-1" hidden="0" type="field" name="opedicao1"/>
+      <column width="-1" hidden="0" type="field" name="datainicioedicao1"/>
+      <column width="-1" hidden="0" type="field" name="datafimedicao1"/>
+      <column width="-1" hidden="0" type="field" name="oprevedicao1"/>
+      <column width="-1" hidden="0" type="field" name="datainiciorevedicao1"/>
+      <column width="-1" hidden="0" type="field" name="datafimrevedicao1"/>
+      <column width="-1" hidden="0" type="field" name="opedicao2"/>
+      <column width="-1" hidden="0" type="field" name="datainicioedicao2"/>
+      <column width="-1" hidden="0" type="field" name="datafimedicao2"/>
+      <column width="-1" hidden="0" type="field" name="area_otf"/>
+      <column width="-1" hidden="1" type="actions"/>
+    </columns>
+  </attributetableconfig>
+  <editform>.</editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath>.</editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- código: utf-8 -*-
+"""
+Formas QGIS podem ter uma função Python que é chamada quando o formulário é
+aberto.
+Use esta função para adicionar lógica extra para seus formulários.
+Digite o nome da função na "função Python Init"
+campo.
+Um exemplo a seguir:
+"""
+de qgis.PyQt.QtWidgets importar QWidget
+
+def my_form_open(diálogo, camada, feição):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>generatedlayout</editorlayout>
+  <widgets/>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <defaults>
+    <default field="id" expression=""/>
+    <default field="mi" expression=""/>
+    <default field="inom" expression=""/>
+    <default field="escala" expression=""/>
+    <default field="nomecarta" expression=""/>
+    <default field="anoaquisicao" expression=""/>
+    <default field="engrespaquisicao" expression=""/>
+    <default field="opaquisicao" expression=""/>
+    <default field="datainicioaquisicao" expression=""/>
+    <default field="datafimaquisicao" expression=""/>
+    <default field="engresprevisaoaquisicao" expression=""/>
+    <default field="oprevisaoaquisicao" expression=""/>
+    <default field="datainiciorevaquisicao" expression=""/>
+    <default field="datafimrevaquisicao" expression=""/>
+    <default field="engrespreambulacao" expression=""/>
+    <default field="opreambulacao" expression=""/>
+    <default field="datainicioreambulacao" expression=""/>
+    <default field="datafimreambulacao" expression=""/>
+    <default field="oprevisaoreambulacao" expression=""/>
+    <default field="engrespvalidacaoedicao" expression=""/>
+    <default field="opvalidacao" expression=""/>
+    <default field="datainiciovalidacao" expression=""/>
+    <default field="datafimvalidacao" expression=""/>
+    <default field="opedicao1" expression=""/>
+    <default field="datainicioedicao1" expression=""/>
+    <default field="datafimedicao1" expression=""/>
+    <default field="oprevedicao1" expression=""/>
+    <default field="datainiciorevedicao1" expression=""/>
+    <default field="datafimrevedicao1" expression=""/>
+    <default field="opedicao2" expression=""/>
+    <default field="datainicioedicao2" expression=""/>
+    <default field="datafimedicao2" expression=""/>
+    <default field="area_otf" expression=""/>
+  </defaults>
+  <previewExpression></previewExpression>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/edgv_213/aquisicao_2CGEO/aux_revisa_p.qml
+++ b/edgv_213/aquisicao_2CGEO/aux_revisa_p.qml
@@ -32,10 +32,10 @@
   <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
     <rules key="{79bf2d05-07e2-4dd4-95f8-23bfa0ea6b68}">
       <rule filter="&quot;rev&quot; = 1" key="{9e370ded-5cb9-4a12-869b-82d2fd70565a}" symbol="0" label="1">
-        <rule filter="&quot;obsoperador&quot; != '''' OR &quot;obsoperador&quot; IS NOT NULL" key="{c9a85d87-48f7-48b4-8bef-e756c533e262}" symbol="1" label="obsoperador"/>
+        <rule filter="length(&quot;obsoperador&quot;) != 0  AND  &quot;obsoperador&quot; IS NOT NULL" key="{c9a85d87-48f7-48b4-8bef-e756c533e262}" symbol="1" label="obsoperador"/>
       </rule>
       <rule filter="&quot;rev&quot; = 2" key="{dadbf146-58ef-4653-bae4-259f2f26a2ee}" symbol="2" label="2">
-        <rule filter="&quot;obsoperador&quot; != '''' OR &quot;obsoperador&quot; IS NOT NULL" key="{9ed0a3e1-66a9-4bb9-83a4-d43a33dc7673}" symbol="3" label="obsoperador"/>
+        <rule filter="length(&quot;obsoperador&quot;) != 0  AND  &quot;obsoperador&quot; IS NOT NULL" key="{9ed0a3e1-66a9-4bb9-83a4-d43a33dc7673}" symbol="3" label="obsoperador"/>
       </rule>
       <rule filter="ELSE" key="{21c96a0f-37b6-4f6d-8e62-4b99aad453b3}" symbol="4"/>
     </rules>

--- a/edgv_213/aquisicao_2CGEO/hid_trecho_drenagem_l.qml
+++ b/edgv_213/aquisicao_2CGEO/hid_trecho_drenagem_l.qml
@@ -100,7 +100,7 @@
   <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
     <rules key="{169f2ddd-fa34-4be8-b3e8-6974bfc4c924}">
       <rule filter="&quot;regime&quot; = 1  AND  length(&quot;nome&quot;)!=0  AND  &quot;nome&quot; IS NOT NULL" key="{32291303-3018-467a-86ce-76d4e4255b5e}" symbol="0" label="Permanente com Nome"/>
-      <rule filter="&quot;regime&quot; = 1" key="{4b58c64e-84b0-4325-88d3-87eff0fa91d8}" symbol="1" label="Permanente"/>
+      <rule filter="&quot;regime&quot; = 1  AND  (length(&quot;nome&quot;)=0   OR  &quot;nome&quot; IS     NULL)" key="{4b58c64e-84b0-4325-88d3-87eff0fa91d8}" symbol="1" label="Permanente"/>
       <rule filter="&quot;regime&quot; = 2" key="{de659dc3-c748-4419-a898-e61871604b8d}" symbol="2" label="Permanente com grande variação"/>
       <rule filter="&quot;regime&quot; = 3" key="{456558c7-9334-45b5-900e-c670ee35c73c}" symbol="3" label="Temporário"/>
       <rule filter="&quot;regime&quot; = 4" key="{3b070710-76e9-47f0-bcd9-aec49c62e26f}" symbol="4" label="Temporário com leito permanente"/>

--- a/edgv_213/aquisicao_2CGEO/hid_trecho_drenagem_l.qml
+++ b/edgv_213/aquisicao_2CGEO/hid_trecho_drenagem_l.qml
@@ -99,8 +99,8 @@
   </edittypes>
   <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
     <rules key="{169f2ddd-fa34-4be8-b3e8-6974bfc4c924}">
-      <rule filter="&quot;regime&quot; = 1 AND &quot;nome&quot; != ''''" key="{32291303-3018-467a-86ce-76d4e4255b5e}" symbol="0" label="Permanente com Nome"/>
-      <rule filter="&quot;regime&quot; = 1     AND     (&quot;nome&quot; = ''''    OR   &quot;nome&quot;  IS  NULL)" key="{4b58c64e-84b0-4325-88d3-87eff0fa91d8}" symbol="1" label="Permanente"/>
+      <rule filter="&quot;regime&quot; = 1  AND  length(&quot;nome&quot;)!=0  AND  &quot;nome&quot; IS NOT NULL" key="{32291303-3018-467a-86ce-76d4e4255b5e}" symbol="0" label="Permanente com Nome"/>
+      <rule filter="&quot;regime&quot; = 1" key="{4b58c64e-84b0-4325-88d3-87eff0fa91d8}" symbol="1" label="Permanente"/>
       <rule filter="&quot;regime&quot; = 2" key="{de659dc3-c748-4419-a898-e61871604b8d}" symbol="2" label="Permanente com grande variação"/>
       <rule filter="&quot;regime&quot; = 3" key="{456558c7-9334-45b5-900e-c670ee35c73c}" symbol="3" label="Temporário"/>
       <rule filter="&quot;regime&quot; = 4" key="{3b070710-76e9-47f0-bcd9-aec49c62e26f}" symbol="4" label="Temporário com leito permanente"/>

--- a/edgv_213/aquisicao_2CGEO/hid_trecho_massa_dagua_a.qml
+++ b/edgv_213/aquisicao_2CGEO/hid_trecho_massa_dagua_a.qml
@@ -57,8 +57,8 @@
   <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
     <rules key="{4ce34ef1-7bc1-4f24-8019-23f9bcd282d9}">
       <rule filter="&quot;tipotrechomassa&quot; = 99" key="{5fb092b2-2f6f-49b3-9183-2e65cdaf5630}" symbol="0" label="Outros"/>
-      <rule filter="&quot;tipotrechomassa&quot;=1 AND  &quot;nome&quot; != ''''" key="{a85a1d7c-8f5a-417a-8c22-45af20805210}" symbol="1" label="Rio com nome"/>
-      <rule filter="&quot;tipotrechomassa&quot;=1 AND   (&quot;nome&quot; = ''''    OR   &quot;nome&quot;  IS  NULL)" key="{6888d81e-2c43-402a-b2d1-d092e8ebe86a}" symbol="2" label="Rio"/>
+      <rule filter="&quot;regime&quot; = 1  AND  length(&quot;nome&quot;)!=0  AND  &quot;nome&quot; IS NOT NULL" key="{a85a1d7c-8f5a-417a-8c22-45af20805210}" symbol="1" label="Rio com nome"/>
+      <rule filter="&quot;tipotrechomassa&quot;=1" key="{6888d81e-2c43-402a-b2d1-d092e8ebe86a}" symbol="2" label="Rio"/>
       <rule filter="&quot;tipotrechomassa&quot;=10" key="{17a8a6ce-ff92-4f38-81a9-a08914980f5a}" symbol="3" label="Represa/aÃ§ude"/>
       <rule filter="&quot;salinidade&quot; = 2" key="{b3200377-f33a-4f3b-80eb-3930fc242636}" symbol="4" label="Salgado"/>
       <rule filter="&quot;tipotrechomassa&quot;=2" key="{41a8d130-8c63-422e-8127-16988057f4c9}" symbol="5" label="Canal"/>

--- a/edgv_213/aquisicao_2CGEO/hid_trecho_massa_dagua_a.qml
+++ b/edgv_213/aquisicao_2CGEO/hid_trecho_massa_dagua_a.qml
@@ -57,9 +57,9 @@
   <renderer-v2 forceraster="0" symbollevels="0" type="RuleRenderer" enableorderby="0">
     <rules key="{4ce34ef1-7bc1-4f24-8019-23f9bcd282d9}">
       <rule filter="&quot;tipotrechomassa&quot; = 99" key="{5fb092b2-2f6f-49b3-9183-2e65cdaf5630}" symbol="0" label="Outros"/>
-      <rule filter="&quot;regime&quot; = 1  AND  length(&quot;nome&quot;)!=0  AND  &quot;nome&quot; IS NOT NULL" key="{a85a1d7c-8f5a-417a-8c22-45af20805210}" symbol="1" label="Rio com nome"/>
-      <rule filter="&quot;tipotrechomassa&quot;=1" key="{6888d81e-2c43-402a-b2d1-d092e8ebe86a}" symbol="2" label="Rio"/>
-      <rule filter="&quot;tipotrechomassa&quot;=10" key="{17a8a6ce-ff92-4f38-81a9-a08914980f5a}" symbol="3" label="Represa/aÃ§ude"/>
+      <rule filter="&quot;tipotrechomassa&quot; = 1  AND  length(&quot;nome&quot;)!=0  AND  &quot;nome&quot; IS NOT NULL" key="{a85a1d7c-8f5a-417a-8c22-45af20805210}" symbol="1" label="Rio com nome"/>
+      <rule filter="&quot;tipotrechomassa&quot; = 1  AND  (length(&quot;nome&quot;)=0   OR  &quot;nome&quot; IS     NULL)" key="{6888d81e-2c43-402a-b2d1-d092e8ebe86a}" symbol="2" label="Rio"/>
+      <rule filter="&quot;tipotrechomassa&quot;=10" key="{17a8a6ce-ff92-4f38-81a9-a08914980f5a}" symbol="3" label="Represa/açude"/>
       <rule filter="&quot;salinidade&quot; = 2" key="{b3200377-f33a-4f3b-80eb-3930fc242636}" symbol="4" label="Salgado"/>
       <rule filter="&quot;tipotrechomassa&quot;=2" key="{41a8d130-8c63-422e-8127-16988057f4c9}" symbol="5" label="Canal"/>
       <rule filter="&quot;tipotrechomassa&quot;=9" key="{0b4d7588-35a7-4bed-b522-c11ac10d61cb}" symbol="6" label="Laguna"/>


### PR DESCRIPTION
Realmente, localmente o QGIS não compreende '''' (4 single quotes) como string vazia para o estilo. Por outro lado, se usar '' (2 single quotes) ou "" (2 double quotes) o PostgreSQL não compreende quando realizar a importação pelo DSGTools.

A forma que encontrei para o estilo funcionar tanto localmente quanto instalado pelo banco foi usar o fato de uma string vazia ter comprimento igual a zero (função length() pra isso).